### PR TITLE
Fixed incorrect stem.quit method usage in Administrator leaf's quit_command method.

### DIFF
--- a/leaves/administrator/controller.rb
+++ b/leaves/administrator/controller.rb
@@ -48,7 +48,7 @@ class Controller < Autumn::Leaf
   # Typing this command will cause the Stem to exit.
   
   def quit_command(stem, sender, reply_to, msg)
-    stem.quit
+    stem.quit(msg)
   end
   ann :quit_command, :protected => true
   


### PR DESCRIPTION
I couldn't get the Administrator leaf's quit_command (!quit) to work, so I dove into the code and found that stem.quit seemed to require a single "msg" parameter, which is absent in the admin leaf code. This commit includes a fix for that.
