### PR TITLE
Fixes bug where leaf controllers recieve nil messages

### DIFF
--- a/libs/leaf.rb
+++ b/libs/leaf.rb
@@ -780,7 +780,7 @@ module Autumn
     def command_exec(name, stem, channel, sender, msg, reply_to)
       cmd_sym = "#{name}_command".to_sym
       return unless respond_to? cmd_sym
-      msg = nil if msg.presence
+      msg = msg.presence
 
       return unless authenticated?(name, stem, channel, sender)
       return unless run_before_filters(name, stem, channel, sender, name, msg)


### PR DESCRIPTION
Bug was caused in commit ee38e8c5 (Manual style changes)

Message would be set as nil when there was a message, as
"stuff".presence => "stuff". Likewise if there was no message,
msg would be kept as "" as "".presence => nil.
